### PR TITLE
fix(#2162): fix side-menu-parent-padding variable

### DIFF
--- a/data/component-design-tokens/side-menu-design-tokens.json
+++ b/data/component-design-tokens/side-menu-design-tokens.json
@@ -4,7 +4,7 @@
     "type": "color"
   },
   "side-menu-group-padding": {
-    "value": "{space.m} {space.none} {space.l} {space.none}",
+    "value": "{space.none}",
     "type": "spacing"
   },
   "side-menu-sub-group-padding": {
@@ -12,7 +12,7 @@
     "type": "spacing"
   },
   "side-menu-parent-padding": {
-    "value": "{space.none}",
+    "value": "{space.xs} {space.m} {space.xs} {space.xl}",
     "type": "spacing"
   },
   "side-menu-group-border-radius": {

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 22 Oct 2024 01:11:46 GMT
+ * Generated on Tue, 22 Oct 2024 23:22:14 GMT
  */
 
 :root {
@@ -158,9 +158,9 @@
   --goa-side-menu-child-color-bg-selected: var(--goa-color-info-background);
   --goa-side-menu-child-color-bg-hover: var(--goa-color-info-background);
   --goa-side-menu-group-border-radius: var(--goa-border-radius-none);
-  --goa-side-menu-parent-padding: var(--goa-space-none);
+  --goa-side-menu-parent-padding: var(--goa-space-xs) var(--goa-space-m) var(--goa-space-xs) var(--goa-space-xl);
   --goa-side-menu-sub-group-padding: var(--goa-space-none) var(--goa-space-none) var(--goa-space-none) var(--goa-space-none);
-  --goa-side-menu-group-padding: var(--goa-space-m) var(--goa-space-none) var(--goa-space-l) var(--goa-space-none);
+  --goa-side-menu-group-padding: var(--goa-space-none);
   --goa-side-menu-group-color-bg: var(--goa-color-greyscale-white);
   --goa-drawer-padding: var(--goa-space-m);
   --goa-container-padding: var(--goa-space-l);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 22 Oct 2024 01:11:46 GMT
+// Generated on Tue, 22 Oct 2024 23:22:14 GMT
 
 $goa-letter-spacing-button: 0.0125rem;
 $goa-font-weight-bold: 700;
@@ -156,9 +156,9 @@ $goa-table-color-border-heading: $goa-color-greyscale-600;
 $goa-side-menu-child-color-bg-selected: $goa-color-info-background;
 $goa-side-menu-child-color-bg-hover: $goa-color-info-background;
 $goa-side-menu-group-border-radius: $goa-border-radius-none;
-$goa-side-menu-parent-padding: $goa-space-none;
+$goa-side-menu-parent-padding: $goa-space-xs $goa-space-m $goa-space-xs $goa-space-xl;
 $goa-side-menu-sub-group-padding: $goa-space-none $goa-space-none $goa-space-none $goa-space-none;
-$goa-side-menu-group-padding: $goa-space-m $goa-space-none $goa-space-l $goa-space-none;
+$goa-side-menu-group-padding: $goa-space-none;
 $goa-side-menu-group-color-bg: $goa-color-greyscale-white;
 $goa-drawer-padding: $goa-space-m;
 $goa-container-padding: $goa-space-l;


### PR DESCRIPTION
I missed this one.
Right now the padding is not correct: 
![image](https://github.com/user-attachments/assets/aa558172-e572-4b7c-b407-9ddc2dc0c590)


![image](https://github.com/user-attachments/assets/343d0271-66d1-4f8b-b910-c9a68038722c)

Correct should be like in the PR.