### PR TITLE
fix(#2162): accordion padding for right and left icon position

### DIFF
--- a/data/component-design-tokens/accordion-design-tokens.json
+++ b/data/component-design-tokens/accordion-design-tokens.json
@@ -31,9 +31,12 @@
     "value": "{borderRadius.m}",
     "type": "borderRadius"
   },
-  "accordion-padding-heading": {
-    "value": "{space.s} {space.m}",
+  "accordion-padding-heading-icon-left": {
+    "value": "{space.s} {space.m} {space.s} 0",
     "type": "spacing"
+  },
+  "accordion-padding-heading-icon-right": {
+    "value": "{space.s} 0 {space.s} {space.m}"
   },
   "accordion-padding-content-wide": {
     "value": "{space.l} {space.l} {space.xl} 56px",

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 22 Oct 2024 23:22:14 GMT
+ * Generated on Tue, 29 Oct 2024 17:07:39 GMT
  */
 
 :root {
@@ -194,7 +194,8 @@
   --goa-accordion-color-bg-heading-hover: var(--goa-color-greyscale-200);
   --goa-accordion-padding-content-narrow: var(--goa-space-l);
   --goa-accordion-padding-content-wide: var(--goa-space-l) var(--goa-space-l) var(--goa-space-xl) 56px;
-  --goa-accordion-padding-heading: var(--goa-space-s) var(--goa-space-m);
+  --goa-accordion-padding-heading-icon-right: var(--goa-space-s) 0 var(--goa-space-s) var(--goa-space-m);
+  --goa-accordion-padding-heading-icon-left: var(--goa-space-s) var(--goa-space-m) var(--goa-space-s) 0;
   --goa-accordion-border-radius: var(--goa-border-radius-m);
   --goa-accordion-divider: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
   --goa-accordion-border: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 22 Oct 2024 23:22:14 GMT
+// Generated on Tue, 29 Oct 2024 17:07:39 GMT
 
 $goa-letter-spacing-button: 0.0125rem;
 $goa-font-weight-bold: 700;
@@ -192,7 +192,8 @@ $goa-button-border-radius: $goa-border-radius-m;
 $goa-accordion-color-bg-heading-hover: $goa-color-greyscale-200;
 $goa-accordion-padding-content-narrow: $goa-space-l;
 $goa-accordion-padding-content-wide: $goa-space-l $goa-space-l $goa-space-xl 56px;
-$goa-accordion-padding-heading: $goa-space-s $goa-space-m;
+$goa-accordion-padding-heading-icon-right: $goa-space-s 0 $goa-space-s $goa-space-m;
+$goa-accordion-padding-heading-icon-left: $goa-space-s $goa-space-m $goa-space-s 0;
 $goa-accordion-border-radius: $goa-border-radius-m;
 $goa-accordion-divider: $goa-border-width-s solid $goa-color-greyscale-200;
 $goa-accordion-border: $goa-border-width-s solid $goa-color-greyscale-200;


### PR DESCRIPTION
Accordion padding is not correct now. 

On production, its padding is as below: 

![image](https://github.com/user-attachments/assets/570103da-47f3-4f0c-b154-259e1c479f89)

Right now on alpha, its padding is as below:
![image](https://github.com/user-attachments/assets/49f5f3bb-f4fa-46dd-b2a6-a63ca9a93776)

And same with when the icon position on the right, we need another token name to define the padding:
![image](https://github.com/user-attachments/assets/89b7daed-c3fa-4b17-bf70-a1b8ada76e72)


After the fix: 

![image](https://github.com/user-attachments/assets/3024c28e-8ef6-4fcb-9075-ec63eb6431c0)
![image](https://github.com/user-attachments/assets/9565997a-f735-46a6-bcc5-2ded1de83f5d)
![image](https://github.com/user-attachments/assets/1b9d97e8-3671-413e-8c34-fb1605ccb839)
![image](https://github.com/user-attachments/assets/3eb0f8e9-6133-44dd-b376-97296406a8ad)
