### PR TITLE
Tooltip component design token updates for v2 styling

### DIFF
--- a/data/component-design-tokens/tooltip-design-tokens.json
+++ b/data/component-design-tokens/tooltip-design-tokens.json
@@ -8,11 +8,11 @@
     "type": "border"
   },
   "tooltip-border-radius": {
-    "value": "{borderRadius.m}",
+    "value": "{borderRadius.xl}",
     "type": "borderRadius"
   },
   "tooltip-color-bg": {
-    "value": "{color.greyscale.700}",
+    "value": "{color.greyscale.600}",
     "type": "color"
   },
   "tooltip-color-text": {
@@ -28,7 +28,7 @@
     "type": "dimension"
   },
   "tooltip-padding": {
-    "value": "6px {space.m} 10px {space.m}",
+    "value": "{space.m}",
     "type": "spacing"
   },
   "tooltip-text-size": {


### PR DESCRIPTION
## Summary
 - Updated tooltip design tokens for V2 styling
 - Border radius: 4px → 12px (borderRadius.m → borderRadius.xl)
 - Background color: greyscale.700 → greyscale.600
 - Padding: custom values → uniform 16px (space.m)

Part of issue [#2998](https://github.com/GovAlta/ui-components/issues/2998) - V2 Component Updates