### PR TITLE
feat(#3070): update badge tokens to v2

### DIFF
--- a/data/component-design-tokens/badge-design-tokens.json
+++ b/data/component-design-tokens/badge-design-tokens.json
@@ -1,6 +1,11 @@
 {
   "badge-padding": {
-    "value": "0px {space.xs}",
+    "value": "0 {space.xs}",
+    "type": "spacing",
+    "description": "0px 8px"
+  },
+  "badge-padding-large": {
+    "value": "0 {space.xs}",
     "type": "spacing",
     "description": "0px 8px"
   },
@@ -14,83 +19,167 @@
     "type": "fontSizes",
     "description": "14px"
   },
+  "badge-font-size-large": {
+    "value": "{fontSize.3}",
+    "type": "fontSizes",
+    "description": "16px"
+  },
   "badge-line-height": {
     "value": "{lineHeight.1}",
     "type": "lineHeights",
     "description": "20px"
   },
+  "badge-line-height-large": {
+    "value": "{lineHeight.2}",
+    "type": "lineHeights",
+    "description": "22px"
+  },
   "badge-icon-size": {
-    "value": "{iconSize.1}",
+    "value": "{iconSize.s}",
     "type": "sizing",
-    "description": "16px"
+    "description": "18px"
+  },
+  "badge-icon-size-large": {
+    "value": "{iconSize.m}",
+    "type": "sizing",
+    "description": "20px"
   },
   "badge-border-radius": {
-    "value": "{borderRadius.m}",
+    "value": "{borderRadius.s}",
     "type": "borderRadius",
-    "description": "4px"
+    "description": "6px"
+  },
+  "badge-border-width": {
+    "value": "{borderWidth.s}",
+    "type": "borderWidth",
+    "description": "1px"
+  },
+  "badge-height": {
+    "value": "24px",
+    "type": "sizing"
+  },
+  "badge-height-large": {
+    "value": "32px",
+    "type": "sizing"
   },
   "badge-info-color-bg": {
-    "value": "{color.greyscale.100}",
+    "value": "{color.info.default}",
     "type": "color"
   },
   "badge-info-color-content": {
-    "value": "{color.info.default}",
+    "value": "{color.info.textInverse}",
     "type": "color"
+  },
+  "badge-info-subtle-color-bg": {
+    "value": "{color.info.light}",
+    "type": "color"
+  },
+  "badge-info-subtle-color-content": {
+    "value": "{color.info.textDark}",
+    "type": "color"
+  },
+  "badge-info-subtle-border": {
+    "value": "inset 0 0 0 {borderWidth.s} {color.info.border}",
+    "type": "dropShadow"
   },
   "badge-success-color-bg": {
     "value": "{color.success.default}",
     "type": "color"
   },
   "badge-success-color-content": {
-    "value": "{color.text.light}",
+    "value": "{color.success.textInverse}",
     "type": "color"
+  },
+  "badge-success-subtle-color-bg": {
+    "value": "{color.success.light}",
+    "type": "color"
+  },
+  "badge-success-subtle-color-content": {
+    "value": "{color.success.textDark}",
+    "type": "color"
+  },
+  "badge-success-subtle-border": {
+    "value": "inset 0 0 0 {borderWidth.s} {color.success.border}",
+    "type": "dropShadow"
   },
   "badge-important-color-bg": {
     "value": "{color.warning.default}",
     "type": "color"
   },
   "badge-important-color-content": {
-    "value": "{color.text.default}",
+    "value": "{color.warning.textDark}",
     "type": "color"
+  },
+  "badge-important-subtle-color-bg": {
+    "value": "{color.warning.light}",
+    "type": "color"
+  },
+  "badge-important-subtle-color-content": {
+    "value": "{color.warning.textDark}",
+    "type": "color"
+  },
+  "badge-important-subtle-border": {
+    "value": "inset 0 0 0 {borderWidth.s} {color.warning.border}",
+    "type": "dropShadow"
   },
   "badge-emergency-color-bg": {
     "value": "{color.emergency.default}",
     "type": "color"
   },
   "badge-emergency-color-content": {
+    "value": "{color.emergency.textInverse}",
+    "type": "color"
+  },
+  "badge-emergency-subtle-color-bg": {
+    "value": "{color.emergency.light}",
+    "type": "color"
+  },
+  "badge-emergency-subtle-color-content": {
+    "value": "{color.emergency.textDark}",
+    "type": "color"
+  },
+  "badge-emergency-subtle-border": {
+    "value": "inset 0 0 0 {borderWidth.s} {color.emergency.border}",
+    "type": "dropShadow"
+  },
+  "badge-default-color-bg": {
+    "value": "{color.greyscale.800}",
+    "type": "color"
+  },
+  "badge-default-color-content": {
     "value": "{color.text.light}",
     "type": "color"
   },
-  "badge-dark-color-bg": {
-    "value": "{color.greyscale.black}",
+  "badge-default-subtle-color-bg": {
+    "value": "{color.greyscale.100}",
     "type": "color"
   },
-  "badge-dark-color-content": {
-    "value": "{color.text.light}",
-    "type": "color"
-  },
-  "badge-midtone-color-bg": {
-    "value": "{color.greyscale.700}",
-    "type": "color"
-  },
-  "badge-midtone-color-content": {
-    "value": "{color.text.light}",
-    "type": "color"
-  },
-  "badge-light-color-bg": {
-    "value": "{color.greyscale.white}",
-    "type": "color"
-  },
-  "badge-light-color-content": {
+  "badge-default-subtle-color-content": {
     "value": "{color.text.default}",
     "type": "color"
   },
-  "badge-height": {
-    "value": "22px",
-    "type": "sizing"
+  "badge-default-subtle-border": {
+    "value": "inset 0 0 0 {borderWidth.s} {color.greyscale.200}",
+    "type": "dropShadow"
   },
-  "badge-border": {
-    "value": "inset 0 0 {borderWidth.s} 0 rgba(0, 0, 0, 0.5)",
-    "type": "other"
+  "badge-archived-color-bg": {
+    "value": "{color.greyscale.200}",
+    "type": "color"
+  },
+  "badge-archived-color-content": {
+    "value": "{color.greyscale.800}",
+    "type": "color"
+  },
+  "badge-archived-subtle-color-bg": {
+    "value": "{color.greyscale.white}",
+    "type": "color"
+  },
+  "badge-archived-subtle-color-content": {
+    "value": "{color.text.default}",
+    "type": "color"
+  },
+  "badge-archived-subtle-border": {
+    "value": "inset 0 0 0 {borderWidth.s} {color.greyscale.200}",
+    "type": "dropShadow"
   }
 }


### PR DESCRIPTION
This PR updates the design tokens to match the new [v2 badge designs](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library-BETA?node-id=56969-153280&t=vQdVzxYLnADo2Ff5-1).