### PR TITLE
feat(#2949) v2 checkbox design tokens

### DIFF
--- a/data/component-design-tokens/checkbox-design-tokens.json
+++ b/data/component-design-tokens/checkbox-design-tokens.json
@@ -1,17 +1,17 @@
 {
   "checkbox-border": {
     "value": {
-      "width": "{borderWidth.s}",
+      "width": "{input.borderWidth.default}",
       "style": "solid",
-      "color": "{color.greyscale.700}"
+      "color": "{input.color.border.default}"
     },
     "type": "border"
   },
   "checkbox-border-disabled": {
     "value": {
-      "width": "{borderWidth.s}",
+      "width": "{input.borderWidth.default}",
       "style": "solid",
-      "color": "{color.greyscale.400}"
+      "color": "{input.color.border.default}"
     },
     "type": "border"
   },
@@ -27,7 +27,7 @@
     "value": {
       "width": "{borderWidth.m}",
       "style": "solid",
-      "color": "{color.interactive.error}"
+      "color": "{input.color.border.error}"
     },
     "type": "border"
   },
@@ -35,7 +35,7 @@
     "value": {
       "width": "{borderWidth.l}",
       "style": "solid",
-      "color": "{color.interactive.focus}"
+      "color": "{input.color.border.focus}"
     },
     "type": "border"
   },
@@ -43,17 +43,24 @@
     "value": {
       "width": "{borderWidth.m}",
       "style": "solid",
-      "color": "{color.interactive.hover}"
+      "color": "{input.color.border.hover}"
+    },
+    "type": "border"
+  },
+  "checkbox-border-error-hover": {
+    "value": {
+      "width": "{borderWidth.m}",
+      "style": "solid",
+      "color": "{input.color.border.error-hover}"
     },
     "type": "border"
   },
   "checkbox-border-radius": {
-    "value": "2px",
-    "type": "borderRadius",
-    "description": "2px"
+    "value": "{input.borderRadius.checkbox}",
+    "type": "borderRadius"
   },
   "checkbox-color-bg": {
-    "value": "{color.greyscale.white}",
+    "value": "{input.color.background.default}",
     "type": "color"
   },
   "checkbox-color-bg-checked": {
@@ -61,7 +68,7 @@
     "type": "color"
   },
   "checkbox-color-bg-checked-disabled": {
-    "value": "{color.interactive.disabled}",
+    "value": "{color.greyscale.300}",
     "type": "color"
   },
   "checkbox-color-bg-checked-error": {
@@ -72,12 +79,16 @@
     "value": "{color.interactive.hover}",
     "type": "color"
   },
+  "checkbox-color-bg-checked-error-hover": {
+    "value": "{color.interactive.error-hover}",
+    "type": "color"
+  },
   "checkbox-color-label": {
-    "value": "{color.text.default}",
+    "value": "{input.color.text.secondary}",
     "type": "color"
   },
   "checkbox-color-label-disabled": {
-    "value": "{color.greyscale.500}",
+    "value": "{input.color.text.disabled}",
     "type": "color"
   },
   "checkbox-description-font-size": {
@@ -85,11 +96,19 @@
     "type": "other"
   },
   "checkbox-gap": {
+    "value": "{space.s}",
+    "type": "spacing"
+  },
+  "checkbox-gap-compact": {
     "value": "{space.xs}",
     "type": "spacing"
   },
   "checkbox-label-font-size": {
     "value": "{typography.body.m}",
+    "type": "other"
+  },
+  "checkbox-label-font-size-compact": {
+    "value": "{typography.body.s}",
     "type": "other"
   },
   "checkbox-size": {


### PR DESCRIPTION
This PR updates the checkbox tokens to match the [v2 Figma component](https://www.figma.com/design/Jpy1Ea5qglwnp1SgGnagY9/%E2%9D%96-Component-library-BETA?node-id=56969-469737&t=FCFdhIPcLhRaL1k3-1). It uses the global input tokens whenever possible.