### PR TITLE
fix(#3231): revert v2 input read-only tokens

### DIFF
--- a/data/component-design-tokens/input-design-tokens.json
+++ b/data/component-design-tokens/input-design-tokens.json
@@ -94,17 +94,5 @@
   "text-input-space-btw-icon-text-compact": {
     "value": "{space.xs}",
     "type": "spacing"
-  },
-  "text-input-border-readonly": {
-    "value": "inset 0 0 0 {input.borderWidth.default} {input.color.border.readonly}",
-    "type": "other"
-  },
-  "text-input-color-bg-readonly": {
-    "value": "{input.color.background.readonly}",
-    "type": "color"
-  },
-  "text-input-lt-content-color-bg-readonly": {
-    "value": "{input.color.background.readonly-content}",
-    "type": "color"
   }
 }


### PR DESCRIPTION
This PR reverts the v2 Input tokens for the read-only state. Learn more in the related PR: https://github.com/GovAlta/ui-components/pull/3230

The issue was discovered during work from this PR: https://github.com/GovAlta/ui-components/pull/3226