### PR TITLE
fix(#3354): remove and test for double goa prefixes

### DIFF
--- a/data/component-design-tokens/table-design-tokens.json
+++ b/data/component-design-tokens/table-design-tokens.json
@@ -7,7 +7,7 @@
     "value": "{color.greyscale.600}",
     "type": "color"
   },
-  "goa-table-header-padding": {
+  "table-header-padding": {
     "value": "{space.m}",
     "type": "sizing"
   }

--- a/index.spec.js
+++ b/index.spec.js
@@ -27,4 +27,16 @@ describe("GoA Design Tokens", () => {
     const raw = fs.readFileSync("./tmp/dist/tokens.scss", { encoding: "utf8" });
     expect(raw).not.toContain("[object Object]");
   });
+
+  it("should not contain double goa prefixes", async () => {
+    SC.generate("./tmp");
+    const raw = fs.readFileSync("./tmp/dist/tokens.css", { encoding: "utf8" });
+    expect(raw).not.toContain("--goa-goa");
+  });
+
+  it("should not contain undefined values", async () => {
+    SC.generate("./tmp");
+    const raw = fs.readFileSync("./tmp/dist/tokens.css", { encoding: "utf8" });
+    expect(raw.toLowerCase()).not.toContain("undefined");
+  });
 });


### PR DESCRIPTION
The PR removes a token with a double `goa` prefix. It also adds tests for double `goa` prefixes and undefined values.