### PR TITLE
fix(#3385): add missing v2 badge borders

### DIFF
--- a/data/component-design-tokens/badge-design-tokens.json
+++ b/data/component-design-tokens/badge-design-tokens.json
@@ -181,5 +181,29 @@
   "badge-archived-subtle-border": {
     "value": "inset 0 0 0 {borderWidth.s} {color.greyscale.200}",
     "type": "dropShadow"
+  },
+  "badge-sky-subtle-border": {
+    "value": "inset 0 0 0 {borderWidth.s} {color.extended.sky.border}",
+    "type": "dropShadow"
+  },
+  "badge-prairie-subtle-border": {
+    "value": "inset 0 0 0 {borderWidth.s} {color.extended.prairie.border}",
+    "type": "dropShadow"
+  },
+  "badge-lilac-subtle-border": {
+    "value": "inset 0 0 0 {borderWidth.s} {color.extended.lilac.border}",
+    "type": "dropShadow"
+  },
+  "badge-pasture-subtle-border": {
+    "value": "inset 0 0 0 {borderWidth.s} {color.extended.pasture.border}",
+    "type": "dropShadow"
+  },
+  "badge-sunset-subtle-border": {
+    "value": "inset 0 0 0 {borderWidth.s} {color.extended.sunset.border}",
+    "type": "dropShadow"
+  },
+  "badge-dawn-subtle-border": {
+    "value": "inset 0 0 0 {borderWidth.s} {color.extended.dawn.border}",
+    "type": "dropShadow"
   }
 }

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 22 Jan 2026 20:50:36 GMT
+ * Generated on Wed, 04 Feb 2026 18:08:00 GMT
  */
 
 :root {
@@ -949,6 +949,12 @@
   --goa-button-padding-compact: 0 var(--goa-space-m);
   --goa-button-padding: 0 var(--goa-space-xl);
   --goa-button-border-radius: var(--goa-border-radius-m);
+  --goa-badge-dawn-subtle-border: inset 0 0 0 var(--goa-border-width-s) var(--goa-color-extended-dawn-border);
+  --goa-badge-sunset-subtle-border: inset 0 0 0 var(--goa-border-width-s) var(--goa-color-extended-sunset-border);
+  --goa-badge-pasture-subtle-border: inset 0 0 0 var(--goa-border-width-s) var(--goa-color-extended-pasture-border);
+  --goa-badge-lilac-subtle-border: inset 0 0 0 var(--goa-border-width-s) var(--goa-color-extended-lilac-border);
+  --goa-badge-prairie-subtle-border: inset 0 0 0 var(--goa-border-width-s) var(--goa-color-extended-prairie-border);
+  --goa-badge-sky-subtle-border: inset 0 0 0 var(--goa-border-width-s) var(--goa-color-extended-sky-border);
   --goa-badge-archived-subtle-border: inset 0 0 0 var(--goa-border-width-s) var(--goa-color-greyscale-200);
   --goa-badge-archived-subtle-color-bg: var(--goa-color-greyscale-white);
   --goa-badge-archived-color-content: var(--goa-color-greyscale-800);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 22 Jan 2026 20:50:36 GMT
+// Generated on Wed, 04 Feb 2026 18:08:00 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
 $goa-accordion-color-bg-content: #ffffff;
@@ -73,6 +73,12 @@ $goa-badge-archived-color-content: #353535;
 $goa-badge-archived-subtle-color-bg: #ffffff;
 $goa-badge-archived-subtle-color-content: #000000;
 $goa-badge-archived-subtle-border: inset 0 0 0 1px #cdcdcd;
+$goa-badge-sky-subtle-border: inset 0 0 0 1px #bff0ee;
+$goa-badge-prairie-subtle-border: inset 0 0 0 1px #ecd386;
+$goa-badge-lilac-subtle-border: inset 0 0 0 1px #e2d2fd;
+$goa-badge-pasture-subtle-border: inset 0 0 0 1px #dee563;
+$goa-badge-sunset-subtle-border: inset 0 0 0 1px #f5ddad;
+$goa-badge-dawn-subtle-border: inset 0 0 0 1px #e9b8d5;
 $goa-button-border-radius: 0.5rem;
 $goa-button-padding: 0 2rem;
 $goa-button-padding-compact: 0 1rem;


### PR DESCRIPTION
This PR adds missing design tokens for v2 subtle badge borders. The related component PR is https://github.com/GovAlta/ui-components/pull/3390.

### Before

The subtle badges with extended colour types have no borders. 😢 

<img width="1466" height="164" alt="image" src="https://github.com/user-attachments/assets/cc24fcb8-ee85-4dfe-af58-4093b00700c0" />

### After

The subtle badges with extended colour types have borders! 🎉 

<img width="1459" height="193" alt="image" src="https://github.com/user-attachments/assets/8304ecdb-d5b2-4de7-9506-b4e1b0f80b8a" />


All tests pass locally. 👍 

<img width="498" height="260" alt="image" src="https://github.com/user-attachments/assets/66ebf68e-2666-4ca2-94ea-ae4671cb582e" />
