### PR TITLE
fix(#3184): rename secondary text header tokens

### DIFF
--- a/data/component-design-tokens/header-design-tokens.json
+++ b/data/component-design-tokens/header-design-tokens.json
@@ -100,25 +100,25 @@
     "value": "13rem",
     "type": "dimension"
   },
-  "app-header-subline-color": {
+  "app-header-secondary-text-color": {
     "value": "{color.text.secondary}",
     "type": "color",
-    "description": "Subline text color"
+    "description": "Secondary text color"
   },
-  "app-header-subline-typography-desktop": {
+  "app-header-secondary-text-typography-desktop": {
     "value": "{typography.body.s}",
     "type": "other",
-    "description": "Subline typography on desktop"
+    "description": "Secondary text typography on desktop"
   },
-  "app-header-subline-typography-mobile": {
+  "app-header-secondary-text-typography-mobile": {
     "value": "{typography.body.xs}",
     "type": "other",
-    "description": "Subline typography on mobile"
+    "description": "Secondary text typography on mobile"
   },
-  "app-header-service-name-subline-gap": {
+  "app-header-service-name-secondary-text-gap": {
     "value": "{space.3xs}",
     "type": "spacing",
-    "description": "Vertical gap between service name and subline"
+    "description": "Vertical gap between service name and secondary text"
   },
   "app-header-service-phase-gap-horizontal": {
     "value": "{space.m}",

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 04 Feb 2026 18:08:00 GMT
+ * Generated on Fri, 20 Feb 2026 17:40:16 GMT
  */
 
 :root {
@@ -697,7 +697,7 @@
   --goa-app-header-utilities-gap: var(--goa-space-s);
   --goa-app-header-service-phase-row-gap: var(--goa-space-xs);
   --goa-app-header-service-phase-gap-horizontal: var(--goa-space-m);
-  --goa-app-header-service-name-subline-gap: var(--goa-space-3xs);
+  --goa-app-header-service-name-secondary-text-gap: var(--goa-space-3xs);
   --goa-app-header-service-name-border-focus: var(--goa-border-width-l) solid var(--goa-color-interactive-focus);
   --goa-app-header-typography-service-name-mobile: var(--goa-font-weight-semi-bold) var(--goa-font-size-3)/var(--goa-line-height-1) var(--goa-font-family-sans);
   --goa-app-header-logo-service-gap-small-screen: var(--goa-space-l);
@@ -1119,9 +1119,9 @@
   --goa-app-header-nav-text-color: var(--goa-color-text-secondary);
   --goa-app-header-color-text-nav-item-current: var(--goa-color-text-secondary);
   --goa-app-header-color-text-nav-item: var(--goa-color-text-secondary);
-  --goa-app-header-subline-typography-mobile: var(--goa-typography-body-xs);
-  --goa-app-header-subline-typography-desktop: var(--goa-typography-body-s);
-  --goa-app-header-subline-color: var(--goa-color-text-secondary);
+  --goa-app-header-secondary-text-typography-mobile: var(--goa-typography-body-xs);
+  --goa-app-header-secondary-text-typography-desktop: var(--goa-typography-body-s);
+  --goa-app-header-secondary-text-color: var(--goa-color-text-secondary);
   --goa-app-header-typography-service-name: var(--goa-typography-heading-xs);
   --goa-app-header-color-service-name: var(--goa-color-text-default);
   --goa-step-typography-sublabel: var(--goa-typography-body-xs);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 04 Feb 2026 18:08:00 GMT
+// Generated on Fri, 20 Feb 2026 17:40:16 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
 $goa-accordion-color-bg-content: #ffffff;
@@ -496,10 +496,10 @@ $goa-app-header-typography-service-name-mobile: 600 1rem/1.25rem acumin-variable
 $goa-app-header-service-name-border-focus: 2px solid #006dcc;
 $goa-app-header-max-width-service-name: 40rem;
 $goa-app-header-min-width-service-name: 13rem;
-$goa-app-header-subline-color: #353535;
-$goa-app-header-subline-typography-desktop: 400 1rem/1.375rem acumin-variable, helvetica-neue, arial, sans-serif;
-$goa-app-header-subline-typography-mobile: 400 0.875rem/1.25rem acumin-variable, helvetica-neue, arial, sans-serif;
-$goa-app-header-service-name-subline-gap: 0.125rem;
+$goa-app-header-secondary-text-color: #353535;
+$goa-app-header-secondary-text-typography-desktop: 400 1rem/1.375rem acumin-variable, helvetica-neue, arial, sans-serif;
+$goa-app-header-secondary-text-typography-mobile: 400 0.875rem/1.25rem acumin-variable, helvetica-neue, arial, sans-serif;
+$goa-app-header-service-name-secondary-text-gap: 0.125rem;
 $goa-app-header-service-phase-gap-horizontal: 1rem;
 $goa-app-header-service-phase-gap-vertical: 6px;
 $goa-app-header-service-phase-row-gap: 0.5rem;


### PR DESCRIPTION
## Summary
- Rename header `subline` tokens to `secondary-text` for consistency with other components (Accordion, FilterChip) that use `secondarytext`

## Changes
- `app-header-subline-color` → `app-header-secondary-text-color`
- `app-header-subline-typography-desktop` → `app-header-secondary-text-typography-desktop`
- `app-header-subline-typography-mobile` → `app-header-secondary-text-typography-mobile`
- `app-header-service-name-subline-gap` → `app-header-service-name-secondary-text-gap`

## Related
- UI Components PR: https://github.com/GovAlta/ui-components/pull/3184