### PR TITLE
fix(#3541): adjusted modal tokens for checkbox issue

### DIFF
--- a/data/component-design-tokens/modal-design-tokens.json
+++ b/data/component-design-tokens/modal-design-tokens.json
@@ -111,7 +111,7 @@
     "description": "Heading section padding"
   },
   "modal-content-padding": {
-    "value": "{space.l} {space.l} {space.xl} {space.l}",
+    "value": "{space.l} 0 {space.xl} 0",
     "type": "spacing",
     "description": "Content section padding"
   },
@@ -126,12 +126,12 @@
     "description": "Outer content wrapper padding"
   },
   "modal-scrollable-padding-desktop": {
-    "value": "0",
+    "value": "{space.l}",
     "type": "spacing",
     "description": "Scrollable component horizontal padding for desktop"
   },
   "modal-scrollable-padding-mobile": {
-    "value": "0",
+    "value": "{space.m}",
     "type": "spacing",
     "description": "Scrollable component horizontal padding for mobile"
   },
@@ -151,7 +151,7 @@
     "description": "Callout variant heading padding for mobile (16px all around)"
   },
   "modal-content-padding-mobile": {
-    "value": "{space.l} {space.m} {space.xl} {space.m}",
+    "value": "{space.l} 0 {space.xl} 0",
     "type": "spacing",
     "description": "Content section padding for mobile (24px top, 16px sides, 32px bottom)"
   },

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 23 Mar 2026 20:16:44 GMT
+ * Generated on Wed, 25 Mar 2026 15:53:56 GMT
  */
 
 :root {
@@ -251,8 +251,6 @@
   --goa-radio-border-radius: 50%;
   --goa-push-drawer-transition-time: 0.25s;
   --goa-circular-progress-color-background: rgba(255, 255, 255, 0.9);
-  --goa-modal-scrollable-padding-mobile: 0;
-  --goa-modal-scrollable-padding-desktop: 0;
   --goa-modal-content-wrapper-padding: 0;
   --goa-modal-max-width: 480px;
   --goa-modal-content-margin-mobile: 0;
@@ -615,12 +613,14 @@
   --goa-modal-callout-information-border: var(--goa-color-info-border);
   --goa-modal-callout-information-bg: var(--goa-color-info-light);
   --goa-modal-actions-padding-mobile: 0 var(--goa-space-m) var(--goa-space-m) var(--goa-space-m);
-  --goa-modal-content-padding-mobile: var(--goa-space-l) var(--goa-space-m) var(--goa-space-xl) var(--goa-space-m);
+  --goa-modal-content-padding-mobile: var(--goa-space-l) 0 var(--goa-space-xl) 0;
   --goa-modal-callout-heading-padding-mobile: var(--goa-space-m);
   --goa-modal-heading-padding-mobile: var(--goa-space-m);
   --goa-modal-callout-heading-padding: var(--goa-space-m) var(--goa-space-l);
+  --goa-modal-scrollable-padding-mobile: var(--goa-space-m);
+  --goa-modal-scrollable-padding-desktop: var(--goa-space-l);
   --goa-modal-actions-padding: 0 var(--goa-space-xl) var(--goa-space-xl) var(--goa-space-xl);
-  --goa-modal-content-padding: var(--goa-space-l) var(--goa-space-l) var(--goa-space-xl) var(--goa-space-l);
+  --goa-modal-content-padding: var(--goa-space-l) 0 var(--goa-space-xl) 0;
   --goa-modal-heading-padding: 20px var(--goa-space-l);
   --goa-modal-heading-border-bottom: var(--goa-border-width-s) solid var(--goa-color-greyscale-150);
   --goa-modal-border: var(--goa-border-width-s) solid var(--goa-color-greyscale-150);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 23 Mar 2026 20:16:44 GMT
+// Generated on Wed, 25 Mar 2026 15:53:56 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
 $goa-accordion-color-bg-content: #ffffff;
@@ -648,15 +648,15 @@ $goa-modal-content-margin-mobile: 0;
 $goa-modal-max-width: 480px;
 $goa-modal-heading-border-bottom: 1px solid #e9e9e9;
 $goa-modal-heading-padding: 20px 1.5rem;
-$goa-modal-content-padding: 1.5rem 1.5rem 2rem 1.5rem;
+$goa-modal-content-padding: 1.5rem 0 2rem 0;
 $goa-modal-actions-padding: 0 2rem 2rem 2rem;
 $goa-modal-content-wrapper-padding: 0;
-$goa-modal-scrollable-padding-desktop: 0;
-$goa-modal-scrollable-padding-mobile: 0;
+$goa-modal-scrollable-padding-desktop: 1.5rem;
+$goa-modal-scrollable-padding-mobile: 1rem;
 $goa-modal-callout-heading-padding: 1rem 1.5rem;
 $goa-modal-heading-padding-mobile: 1rem;
 $goa-modal-callout-heading-padding-mobile: 1rem;
-$goa-modal-content-padding-mobile: 1.5rem 1rem 2rem 1rem;
+$goa-modal-content-padding-mobile: 1.5rem 0 2rem 0;
 $goa-modal-actions-padding-mobile: 0 1rem 1rem 1rem;
 $goa-modal-callout-information-bg: #ebf8ff;
 $goa-modal-callout-information-border: #cbeaf7;


### PR DESCRIPTION
# Summary
Modified the v2 modal tokens to fix issue #3541: left side of checkboxes being cut off by edge of modal.
<img width="648" height="244" alt="image" src="https://github.com/user-attachments/assets/842550e2-9602-4a3c-9d5f-24c1dec15426" />

# Before the change
- `--goa-modal-content-padding-mobile: var(--goa-space-l) var(--goa-space-m) var(--goa-space-xl) var(--goa-space-m);`
- `--goa-modal-content-padding: var(--goa-space-l) var(--goa-space-l) var(--goa-space-xl) var(--goa-space-l);`
- `--goa-modal-scrollable-padding-mobile: 0;`
- `--goa-modal-scrollable-padding-desktop: 0;`

# After the change
- `--goa-modal-content-padding-mobile: var(--goa-space-l) 0 var(--goa-space-xl) 0;`
- `--goa-modal-content-padding: var(--goa-space-l) 0 var(--goa-space-xl) 0;`
- `--goa-modal-scrollable-padding-mobile: var(--goa-space-m);`
- `--goa-modal-scrollable-padding-desktop: var(--goa-space-l);`