### PR TITLE
fix(#3614): add missing IconButton padding tokens

### DIFF
--- a/data/component-design-tokens/icon-button-design-tokens.json
+++ b/data/component-design-tokens/icon-button-design-tokens.json
@@ -1,4 +1,12 @@
 {
+  "icon-button-2xsmall-padding": {
+    "value": "{space.3xs}",
+    "type": "spacing"
+  },
+  "icon-button-xsmall-padding": {
+    "value": "{space.2xs}",
+    "type": "spacing"
+  },
   "icon-button-small-padding": {
     "value": "{space.2xs}",
     "type": "spacing"
@@ -14,6 +22,10 @@
   "icon-button-border-radius": {
     "value": "{borderRadius.m}",
     "type": "borderRadius"
+  },
+  "icon-button-xlarge-padding": {
+    "value": "{space.s}",
+    "type": "spacing"
   },
   "icon-button-focus-border-width": {
     "value": "{input.borderWidth.focus}",

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 23 Mar 2026 20:16:44 GMT
+ * Generated on Wed, 25 Mar 2026 20:35:05 GMT
  */
 
 :root {
@@ -689,10 +689,13 @@
   --goa-icon-button-default-color: var(--goa-color-interactive-default);
   --goa-icon-button-large-border-radius: var(--goa-border-radius-xl);
   --goa-icon-button-medium-border-radius: var(--goa-border-radius-m);
+  --goa-icon-button-xlarge-padding: var(--goa-space-s);
   --goa-icon-button-border-radius: var(--goa-border-radius-m);
   --goa-icon-button-large-padding: var(--goa-space-s);
   --goa-icon-button-medium-padding: var(--goa-space-xs);
   --goa-icon-button-small-padding: var(--goa-space-2xs);
+  --goa-icon-button-xsmall-padding: var(--goa-space-2xs);
+  --goa-icon-button-2xsmall-padding: var(--goa-space-3xs);
   --goa-hero-banner-content-gap: var(--goa-space-l) 0 0;
   --goa-hero-banner-mobile-padding: var(--goa-space-xl) 0;
   --goa-hero-banner-padding: var(--goa-space-2xl) 0;

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 23 Mar 2026 20:16:44 GMT
+// Generated on Wed, 25 Mar 2026 20:35:05 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
 $goa-accordion-color-bg-content: #ffffff;
@@ -532,10 +532,13 @@ $goa-hero-banner-mobile-padding: 2rem 0;
 $goa-hero-banner-content-gap: 1.5rem 0 0;
 $goa-hero-banner-heading: 700 2.5rem/3rem acumin-variable, helvetica-neue, arial, sans-serif;
 $goa-hero-banner-content: 400 1.5rem/2.25rem acumin-variable, helvetica-neue, arial, sans-serif;
+$goa-icon-button-2xsmall-padding: 0.125rem;
+$goa-icon-button-xsmall-padding: 0.25rem;
 $goa-icon-button-small-padding: 0.25rem;
 $goa-icon-button-medium-padding: 0.5rem;
 $goa-icon-button-large-padding: 0.75rem;
 $goa-icon-button-border-radius: 0.5rem;
+$goa-icon-button-xlarge-padding: 0.75rem;
 $goa-icon-button-focus-border-width: 2px;
 $goa-icon-button-focus-border-color: #006dcc;
 $goa-icon-button-medium-border-radius: 0.5rem;


### PR DESCRIPTION
This PR adds the `padding` tokens that were missing for `2xsmall`, `xsmall`, and, `xlarge`.

This PR relates to https://github.com/GovAlta/ui-components/issues/3614