### PR TITLE
fix(#3635): add in custom color token for leading icon on input

### DIFF
--- a/data/component-design-tokens/input-design-tokens.json
+++ b/data/component-design-tokens/input-design-tokens.json
@@ -106,5 +106,9 @@
   "text-input-lt-content-color-bg-readonly": {
     "value": "{input.color.background.readonly-content}",
     "type": "color"
+  },
+  "text-input-color-icon": {
+    "value": "{color.greyscale.600}",
+    "type": "color"
   }
 }

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 26 Mar 2026 17:47:19 GMT
+ * Generated on Tue, 31 Mar 2026 22:36:08 GMT
  */
 
 :root {
@@ -668,6 +668,7 @@
   --goa-linear-progress-color-track: var(--goa-color-greyscale-200);
   --goa-linear-progress-border-radius: var(--goa-border-radius-m);
   --goa-linear-progress-height: var(--goa-space-2xs);
+  --goa-text-input-color-icon: var(--goa-color-greyscale-600);
   --goa-text-input-space-btw-icon-text-compact: var(--goa-space-xs);
   --goa-text-input-padding-compact: var(--goa-space-2xs) var(--goa-text-input-padding-compact-lr);
   --goa-text-input-padding-compact-lr: var(--goa-space-s);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 26 Mar 2026 17:47:19 GMT
+// Generated on Tue, 31 Mar 2026 22:36:08 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
 $goa-accordion-color-bg-content: #ffffff;
@@ -581,6 +581,7 @@ $goa-text-input-space-btw-icon-text-compact: 0.5rem;
 $goa-text-input-border-readonly: inset 0 0 0 1px #e1dedd;
 $goa-text-input-color-bg-readonly: #f2f0f0;
 $goa-text-input-lt-content-color-bg-readonly: #e9e9e9;
+$goa-text-input-color-icon: #6f6f6f;
 $goa-linear-progress-height: 0.25rem;
 $goa-linear-progress-border-radius: 0.5rem;
 $goa-linear-progress-color-track: #cdcdcd;


### PR DESCRIPTION
# Summary
Added the  `--goa-text-input-colour-icon` token for the leading icon color to be lighter than the text colour on inputs.

# Before (the addition)
<img width="422" height="235" alt="image" src="https://github.com/user-attachments/assets/d4ed3521-8ba2-40ed-bc21-77009d7cfdee" />

# After (the addition)
<img width="418" height="230" alt="image" src="https://github.com/user-attachments/assets/ce509859-7c03-4b31-bbef-aba32c56e003" />

Linked issue: [#3635](https://github.com/GovAlta/ui-components/issues/3635)