### PR TITLE
fix(#3638): change container heading background token

### DIFF
--- a/data/component-design-tokens/container-design-tokens.json
+++ b/data/component-design-tokens/container-design-tokens.json
@@ -70,7 +70,7 @@
     "type": "color"
   },
   "container-non-interactive-heading-bg-color": {
-    "value": "{color.greyscale.50}",
+    "value": "{color.greyscale.100}",
     "type": "color"
   },
   "container-non-interactive-heading-text-color": {

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -859,7 +859,7 @@
   --goa-container-info-heading-bg-color: var(--goa-color-info-default);
   --goa-container-info-bg-color: var(--goa-color-info-background);
   --goa-container-non-interactive-border: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
-  --goa-container-non-interactive-heading-bg-color: var(--goa-color-greyscale-50);
+  --goa-container-non-interactive-heading-bg-color: var(--goa-color-greyscale-100);
   --goa-container-non-interactive-bg-color: var(--goa-color-greyscale-50);
   --goa-container-interactive-border: var(--goa-border-width-s) solid var(--goa-color-brand-default);
   --goa-container-interactive-heading-bg-color: var(--goa-color-brand-default);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -254,7 +254,7 @@ $goa-container-interactive-heading-bg-color: #0081a2;
 $goa-container-interactive-heading-text-color: #ffffff;
 $goa-container-interactive-border: 1px solid #0081a2;
 $goa-container-non-interactive-bg-color: #f8f8f8;
-$goa-container-non-interactive-heading-bg-color: #f8f8f8;
+$goa-container-non-interactive-heading-bg-color: #f2f0f0;
 $goa-container-non-interactive-heading-text-color: #000000;
 $goa-container-non-interactive-border: 1px solid #cdcdcd;
 $goa-container-info-bg-color: #f4fdff;


### PR DESCRIPTION
# Before (the change)
Header of the container component colour is too close to the content body. `--goa-container-non-interactive-heading-bg-color` is previously `greyscale-50`

<img width="1085" height="245" alt="image" src="https://github.com/user-attachments/assets/8802674d-b4b0-48ac-ae95-49b5b17f8e27" />

# After (the change)
`--goa-container-non-interactive-heading-bg-color` is now `greyscale-100`

<img width="1096" height="258" alt="image" src="https://github.com/user-attachments/assets/a620ac9f-cac4-4245-86b2-a9948ed3e772" />

Linked issue: #3638[](https://github.com/GovAlta/ui-components/issues/3638)