### PR TITLE
fix(#3637): add in checkbox token within table header to prevent height increase.

### DIFF
--- a/data/component-design-tokens/table-design-tokens.json
+++ b/data/component-design-tokens/table-design-tokens.json
@@ -121,6 +121,11 @@
     "type": "spacing",
     "description": "Vertical padding for checkbox cells in relaxed variant (10px for 64px height)"
   },
+  "table-padding-cell-checkbox-bottom": {
+    "value": "calc({space.m} - 1px)",
+    "type": "spacing",
+    "description": "Vertical padding for checkbox cells in normal variant (16px for 48px height)"
+  },
   "table-padding-cell-form-field": {
     "value": "3px",
     "type": "spacing",

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 25 Mar 2026 15:53:56 GMT
+ * Generated on Mon, 30 Mar 2026 21:15:34 GMT
  */
 
 :root {
@@ -451,6 +451,7 @@
   --goa-table-sort-header-gap: var(--goa-space-xs);
   --goa-table-padding-cell-text-supporting-relaxed: var(--goa-space-xs);
   --goa-table-padding-cell-badge: var(--goa-space-s);
+  --goa-table-padding-cell-checkbox-bottom: calc(var(--goa-space-m) - 1px);
   --goa-table-padding-cell-checkbox: var(--goa-space-3xs);
   --goa-table-padding-cell-text: var(--goa-space-s);
   --goa-table-padding-data-relaxed: 18px var(--goa-space-m) 18px var(--goa-space-m);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 25 Mar 2026 15:53:56 GMT
+// Generated on Mon, 30 Mar 2026 21:15:34 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
 $goa-accordion-color-bg-content: #ffffff;
@@ -859,6 +859,7 @@ $goa-table-padding-cell-text: 0.75rem;
 $goa-table-padding-cell-text-relaxed: 20px;
 $goa-table-padding-cell-checkbox: 0.125rem;
 $goa-table-padding-cell-checkbox-relaxed: 10px;
+$goa-table-padding-cell-checkbox-bottom: calc(1rem - 1px);
 $goa-table-padding-cell-form-field: 3px;
 $goa-table-padding-cell-form-field-relaxed: 11px;
 $goa-table-padding-cell-badge: 0.75rem;


### PR DESCRIPTION
# Before (the change)
Height increases with the checkbox added to the header row.
<img width="1123" height="96" alt="Screenshot 2026-03-31 110820" src="https://github.com/user-attachments/assets/2bcca381-73f3-4ef3-8a0d-f6374c0b23bb" />

# After (the change)
Along with applying an existing token to the top padding of the checkbox, I added new token to the bottom padding of the checkbox on header so it lines up with the rest of the header row.
<img width="1142" height="92" alt="Screenshot 2026-03-31 110831" src="https://github.com/user-attachments/assets/14eb6657-73b3-4247-9234-429d39f692b2" />
<img width="320" height="269" alt="Screenshot 2026-03-31 110839" src="https://github.com/user-attachments/assets/50b73420-4841-4588-8c65-723fde1fead6" />

Linked ui-components PR: [#3637](https://github.com/GovAlta/ui-components/pull/3719)
