### PR TITLE
fix: set container shadow to none

### DIFF
--- a/data/component-design-tokens/container-design-tokens.json
+++ b/data/component-design-tokens/container-design-tokens.json
@@ -12,7 +12,7 @@
     "type": "border"
   },
   "container-shadow": {
-    "value": "{shadow.200}",
+    "value": "none",
     "type": "other"
   },
   "container-padding": {


### PR DESCRIPTION
## Summary
Set `container-shadow` to `none`. The container component should not have a shadow.

Related: GovAlta/ui-components#3804 (depends on this token)