### PR TITLE
fix: dropdown default item text color to text-secondary

### DIFF
--- a/data/component-design-tokens/dropdown-design-tokens.json
+++ b/data/component-design-tokens/dropdown-design-tokens.json
@@ -80,7 +80,7 @@
     "type": "color"
   },
   "dropdown-item-color-text": {
-    "value": "{color.text.default}",
+    "value": "{color.text.secondary}",
     "type": "color"
   },
   "dropdown-item-color-text-disabled": {


### PR DESCRIPTION
## Summary
Change `dropdown-item-color-text` from `text.default` to `text.secondary` so non-selected, non-hovered menu options use the secondary text color.

Related: GovAlta/ui-components#3808