### PR TITLE
fix: drawer content vertical padding to space-l

### DIFF
--- a/data/component-design-tokens/drawer-design-tokens.json
+++ b/data/component-design-tokens/drawer-design-tokens.json
@@ -20,7 +20,7 @@
     "description": "Horizontal padding for content section"
   },
   "drawer-content-padding-vertical": {
-    "value": "{space.m}",
+    "value": "{space.l}",
     "type": "spacing",
     "description": "Vertical padding for content section"
   },


### PR DESCRIPTION
## Summary
Change `drawer-content-padding-vertical` from `space.m` (16px) to `space.l` (24px). The content area needs consistent 24px padding on all sides.

Related: GovAlta/ui-components#3630