### PR TITLE
fix(#3743): changed tertiary button token on mobile to "transparent"

### DIFF
--- a/data/component-design-tokens/button-design-tokens.json
+++ b/data/component-design-tokens/button-design-tokens.json
@@ -309,7 +309,7 @@
     "type": "color"
   },
   "button-tertiary-color-bg-mobile": {
-    "value": "{color.greyscale.100}",
+    "value": "transparent",
     "type": "color"
   },
   "button-tertiary-color-text": {

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 13 Apr 2026 14:47:40 GMT
+ * Generated on Tue, 14 Apr 2026 14:58:40 GMT
  */
 
 :root {
@@ -311,6 +311,7 @@
   --goa-button-letter-spacing: 0.0125rem;
   --goa-button-tertiary-focus-color-bg: transparent;
   --goa-button-tertiary-hover-color-bg: transparent;
+  --goa-button-tertiary-color-bg-mobile: transparent;
   --goa-button-tertiary-color-bg: transparent;
   --goa-button-compact-gap: 0.375rem;
   --goa-button-outline-offset: 2px;
@@ -952,7 +953,6 @@
   --goa-button-tertiary-focus-border: var(--goa-border-width-s) solid var(--goa-color-greyscale-black);
   --goa-button-tertiary-hover-border: var(--goa-border-width-s) solid var(--goa-color-greyscale-black);
   --goa-button-tertiary-border: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
-  --goa-button-tertiary-color-bg-mobile: var(--goa-color-greyscale-100);
   --goa-button-secondary-inverse-focus-border: var(--goa-border-width-none) solid transparent;
   --goa-button-secondary-inverse-hover-border: var(--goa-border-width-none) solid transparent;
   --goa-button-secondary-inverse-border: var(--goa-border-width-none) solid transparent;

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 13 Apr 2026 14:47:40 GMT
+// Generated on Tue, 14 Apr 2026 14:58:40 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
 $goa-accordion-color-bg-content: #ffffff;
@@ -141,7 +141,7 @@ $goa-button-secondary-inverse-border: 0px solid transparent;
 $goa-button-secondary-inverse-hover-border: 0px solid transparent;
 $goa-button-secondary-inverse-focus-border: 0px solid transparent;
 $goa-button-tertiary-color-bg: transparent;
-$goa-button-tertiary-color-bg-mobile: #f2f0f0;
+$goa-button-tertiary-color-bg-mobile: transparent;
 $goa-button-tertiary-color-text: #000000;
 $goa-button-tertiary-border: 1px solid #cdcdcd;
 $goa-button-tertiary-hover-color-bg: transparent;


### PR DESCRIPTION
# Before (the change)

The `--goa-button-tertiary-color-bg-mobile` token still retained the `--goa-color-greyscale-100` value.
<img width="389" height="516" alt="Screenshot 2026-04-15 090956" src="https://github.com/user-attachments/assets/45f0d572-7843-41f2-a0e2-4f0fcb9ae1b9" />

# After (the change)

Changed token to `transparent`, so tertiary button background is now clear on mobile.
<img width="389" height="521" alt="image" src="https://github.com/user-attachments/assets/e7d98533-11ec-4626-b8bc-92a8c855e97b" />
