### PR TITLE
feat(#3873): add work-side-menu-account-bg token

### DIFF
--- a/data/component-design-tokens/work-side-menu-design-tokens.json
+++ b/data/component-design-tokens/work-side-menu-design-tokens.json
@@ -27,6 +27,10 @@
     "value": "{shadow.500}",
     "type": "other"
   },
+  "work-side-menu-account-bg": {
+    "value": "{color.greyscale.white}",
+    "type": "color"
+  },
   "work-side-menu-text-color": {
     "value": "{color.greyscale.600}",
     "type": "color"

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 16 Apr 2026 15:24:12 GMT
+ * Generated on Fri, 24 Apr 2026 04:24:43 GMT
  */
 
 :root {
@@ -418,6 +418,7 @@
   --goa-work-side-menu-transition-duration-medium: var(--goa-motion-duration-medium-2);
   --goa-work-side-menu-mobile-bg: var(--goa-color-greyscale-50);
   --goa-work-side-menu-text-color: var(--goa-color-greyscale-600);
+  --goa-work-side-menu-account-bg: var(--goa-color-greyscale-white);
   --goa-work-side-menu-account-shadow: var(--goa-shadow-500);
   --goa-work-side-menu-border: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
   --goa-work-side-menu-border-radius: var(--goa-border-radius-m);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Thu, 16 Apr 2026 15:24:12 GMT
+// Generated on Fri, 24 Apr 2026 04:24:43 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
 $goa-accordion-color-bg-content: #ffffff;
@@ -953,6 +953,7 @@ $goa-work-side-menu-color-bg: transparent;
 $goa-work-side-menu-border-radius: 0.5rem;
 $goa-work-side-menu-border: 1px solid #cdcdcd;
 $goa-work-side-menu-account-shadow: 0px 12px 20px -8px #1a1a1a3d;
+$goa-work-side-menu-account-bg: #ffffff;
 $goa-work-side-menu-text-color: #6f6f6f;
 $goa-work-side-menu-mobile-bg: #f8f8f8;
 $goa-work-side-menu-transition-duration-medium: 300ms;


### PR DESCRIPTION
Adds a `work-side-menu-account-bg` token for the WorkSideMenu account popover background, next to the existing `work-side-menu-account-shadow`.

The WorkSideMenu component in GovAlta/ui-components already references `--goa-work-side-menu-account-bg` with a fallback to `--goa-color-greyscale-white`, so the token can be overridden independently to enable dark mode. See GovAlta/ui-components#3874 for the Svelte-side change.

Refs GovAlta/ui-components#3873