### PR TITLE
chore(#3636): Added the 'filled' Accordion header style

### DIFF
--- a/data/component-design-tokens/accordion-design-tokens.json
+++ b/data/component-design-tokens/accordion-design-tokens.json
@@ -3,6 +3,10 @@
     "value": "{color.greyscale.white}",
     "type": "color"
   },
+  "accordion-color-filled-bg-heading": {
+    "value": "{color.greyscale.100}",
+    "type": "color"
+  },
   "accordion-color-bg-content": {
     "value": "{color.greyscale.white}",
     "type": "color"
@@ -74,6 +78,10 @@
   },
   "accordion-color-bg-heading-hover": {
     "value": "{color.greyscale.50}",
+    "type": "color"
+  },
+  "accordion-color-filled-bg-heading-hover": {
+    "value": "{color.greyscale.150}",
     "type": "color"
   },
   "accordion-color-heading-hover": {

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Thu, 16 Apr 2026 15:24:12 GMT
+ * Generated on Thu, 23 Apr 2026 22:36:01 GMT
  */
 
 :root {
@@ -1056,6 +1056,7 @@
   --goa-accordion-heading: var(--goa-font-weight-medium) var(--goa-font-size-4)/var(--goa-line-height-4) var(--goa-font-family-sans);
   --goa-accordion-border-hover: var(--goa-border-width-s) solid var(--goa-color-greyscale-black);
   --goa-accordion-border-focus: 3px solid var(--goa-color-interactive-focus);
+  --goa-accordion-color-filled-bg-heading-hover: var(--goa-color-greyscale-150);
   --goa-accordion-color-bg-heading-hover: var(--goa-color-greyscale-50);
   --goa-accordion-padding-content-narrow: var(--goa-space-l);
   --goa-accordion-padding-content-wide: var(--goa-space-l) var(--goa-space-l) var(--goa-space-xl) 56px;
@@ -1069,6 +1070,7 @@
   --goa-accordion-divider: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
   --goa-accordion-border: var(--goa-border-width-s) solid var(--goa-color-greyscale-200);
   --goa-accordion-color-bg-content: var(--goa-color-greyscale-white);
+  --goa-accordion-color-filled-bg-heading: var(--goa-color-greyscale-100);
   --goa-accordion-color-bg-heading: var(--goa-color-greyscale-white);
   --goa-input-color-text-default: var(--goa-color-text-default);
   --goa-work-side-menu-item-text-size: var(--goa-typography-body-s);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,8 +1,9 @@
 
 // Do not edit directly
-// Generated on Thu, 16 Apr 2026 15:24:12 GMT
+// Generated on Thu, 23 Apr 2026 22:36:01 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
+$goa-accordion-color-filled-bg-heading: #f2f0f0;
 $goa-accordion-color-bg-content: #ffffff;
 $goa-accordion-color-heading: #000000;
 $goa-accordion-border: 1px solid #cdcdcd;
@@ -17,6 +18,7 @@ $goa-accordion-padding-heading-m-icon-right: calc(0.75rem - 1px) 0 calc(0.75rem 
 $goa-accordion-padding-content-wide: 1.5rem 1.5rem 2rem 56px;
 $goa-accordion-padding-content-narrow: 1.5rem;
 $goa-accordion-color-bg-heading-hover: #f8f8f8;
+$goa-accordion-color-filled-bg-heading-hover: #e9e9e9;
 $goa-accordion-color-heading-hover: #000000;
 $goa-accordion-border-focus: 3px solid #006dcc;
 $goa-accordion-border-hover: 1px solid #000000;


### PR DESCRIPTION
This PR adds new header styles for the "filled" accordion header styles:

- `accordion-color-filled-bg-heading`
- `accordion-color-filled-bg-heading-hover`

This is to support https://github.com/GovAlta/ui-components/pull/3859