### PR TITLE
fix(#3605): focus border thickness

### DIFF
--- a/data/component-design-tokens/details-design-tokens.json
+++ b/data/component-design-tokens/details-design-tokens.json
@@ -46,7 +46,7 @@
   },
   "details-focus-border": {
     "value": {
-      "width": "{borderWidth.xl}",
+      "width": "{borderWidth.l}",
       "style": "solid",
       "color": "{color.interactive.focus}"
     },

--- a/data/component-design-tokens/notification-banner-design-tokens.json
+++ b/data/component-design-tokens/notification-banner-design-tokens.json
@@ -192,27 +192,27 @@
     "type": "color"
   },
   "notification-banner-information-high-focus-border": {
-    "value": "0 0 0 3px {color.greyscale.white}",
+    "value": "0 0 0 {borderWidth.l} {color.greyscale.white}",
     "type": "other"
   },
   "notification-banner-information-low-focus-border": {
-    "value": "0 0 0 3px {color.info.dark}",
+    "value": "0 0 0 {borderWidth.l} {color.info.dark}",
     "type": "other"
   },
   "notification-banner-important-high-focus-border": {
-    "value": "0 0 0 3px {color.important.text-dark}",
+    "value": "0 0 0 {borderWidth.l} {color.important.text-dark}",
     "type": "other"
   },
   "notification-banner-important-low-focus-border": {
-    "value": "0 0 0 3px {color.important.text-dark}",
+    "value": "0 0 0 {borderWidth.l} {color.important.text-dark}",
     "type": "other"
   },
   "notification-banner-emergency-high-focus-border": {
-    "value": "0 0 0 3px {color.greyscale.white}",
+    "value": "0 0 0 {borderWidth.l} {color.greyscale.white}",
     "type": "other"
   },
   "notification-banner-emergency-low-focus-border": {
-    "value": "0 0 0 3px {color.emergency.dark}",
+    "value": "0 0 0 {borderWidth.l} {color.emergency.dark}",
     "type": "other"
   },
   "notification-banner-information-high-close-bg-hover": {

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Tue, 05 May 2026 21:43:29 GMT
+ * Generated on Tue, 12 May 2026 15:56:06 GMT
  */
 
 :root {
@@ -609,12 +609,12 @@
   --goa-notification-banner-important-high-close-bg-hover: var(--goa-color-important-default);
   --goa-notification-banner-information-low-close-bg-hover: var(--goa-color-info-border);
   --goa-notification-banner-information-high-close-bg-hover: var(--goa-color-info-dark);
-  --goa-notification-banner-emergency-low-focus-border: 0 0 0 3px var(--goa-color-emergency-dark);
-  --goa-notification-banner-emergency-high-focus-border: 0 0 0 3px var(--goa-color-greyscale-white);
-  --goa-notification-banner-important-low-focus-border: 0 0 0 3px var(--goa-color-important-text-dark);
-  --goa-notification-banner-important-high-focus-border: 0 0 0 3px var(--goa-color-important-text-dark);
-  --goa-notification-banner-information-low-focus-border: 0 0 0 3px var(--goa-color-info-dark);
-  --goa-notification-banner-information-high-focus-border: 0 0 0 3px var(--goa-color-greyscale-white);
+  --goa-notification-banner-emergency-low-focus-border: 0 0 0 var(--goa-border-width-l) var(--goa-color-emergency-dark);
+  --goa-notification-banner-emergency-high-focus-border: 0 0 0 var(--goa-border-width-l) var(--goa-color-greyscale-white);
+  --goa-notification-banner-important-low-focus-border: 0 0 0 var(--goa-border-width-l) var(--goa-color-important-text-dark);
+  --goa-notification-banner-important-high-focus-border: 0 0 0 var(--goa-border-width-l) var(--goa-color-important-text-dark);
+  --goa-notification-banner-information-low-focus-border: 0 0 0 var(--goa-border-width-l) var(--goa-color-info-dark);
+  --goa-notification-banner-information-high-focus-border: 0 0 0 var(--goa-border-width-l) var(--goa-color-greyscale-white);
   --goa-notification-banner-emergency-low-color-border: var(--goa-color-emergency-border);
   --goa-notification-banner-emergency-low-color-icon: var(--goa-color-emergency-dark);
   --goa-notification-banner-emergency-low-color-text: var(--goa-color-emergency-dark);
@@ -889,7 +889,7 @@
   --goa-details-padding-left: var(--goa-space-xs);
   --goa-details-padding-bottom: var(--goa-space-xs);
   --goa-details-margin-bottom: var(--goa-space-xs);
-  --goa-details-focus-border: var(--goa-border-width-xl) solid var(--goa-color-interactive-focus);
+  --goa-details-focus-border: var(--goa-border-width-l) solid var(--goa-color-interactive-focus);
   --goa-details-content-padding-top: var(--goa-space-s);
   --goa-details-content-padding-right: var(--goa-space-m);
   --goa-details-content-padding-bottom: var(--goa-space-s);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Tue, 05 May 2026 21:43:29 GMT
+// Generated on Tue, 12 May 2026 15:56:06 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
 $goa-accordion-color-filled-bg-heading: #f2f0f0;
@@ -334,7 +334,7 @@ $goa-details-content-padding-bottom: 0.75rem;
 $goa-details-content-padding-left: 19px;
 $goa-details-content-padding-right: 1rem;
 $goa-details-content-padding-top: 0.75rem;
-$goa-details-focus-border: 3px solid #006dcc;
+$goa-details-focus-border: 2px solid #006dcc;
 $goa-details-margin-bottom: 0.5rem;
 $goa-details-padding-bottom: 0.5rem;
 $goa-details-padding-left: 0.5rem;
@@ -755,12 +755,12 @@ $goa-notification-banner-emergency-low-color-bg: #fdded9;
 $goa-notification-banner-emergency-low-color-text: #a91a10;
 $goa-notification-banner-emergency-low-color-icon: #a91a10;
 $goa-notification-banner-emergency-low-color-border: #eeaea5;
-$goa-notification-banner-information-high-focus-border: 0 0 0 3px #ffffff;
-$goa-notification-banner-information-low-focus-border: 0 0 0 3px #004a8f;
-$goa-notification-banner-important-high-focus-border: 0 0 0 3px #4d3700;
-$goa-notification-banner-important-low-focus-border: 0 0 0 3px #4d3700;
-$goa-notification-banner-emergency-high-focus-border: 0 0 0 3px #ffffff;
-$goa-notification-banner-emergency-low-focus-border: 0 0 0 3px #a91a10;
+$goa-notification-banner-information-high-focus-border: 0 0 0 2px #ffffff;
+$goa-notification-banner-information-low-focus-border: 0 0 0 2px #004a8f;
+$goa-notification-banner-important-high-focus-border: 0 0 0 2px #4d3700;
+$goa-notification-banner-important-low-focus-border: 0 0 0 2px #4d3700;
+$goa-notification-banner-emergency-high-focus-border: 0 0 0 2px #ffffff;
+$goa-notification-banner-emergency-low-focus-border: 0 0 0 2px #a91a10;
 $goa-notification-banner-information-high-close-bg-hover: #004a8f;
 $goa-notification-banner-information-low-close-bg-hover: #cbeaf7;
 $goa-notification-banner-important-high-close-bg-hover: #f9ce2d;


### PR DESCRIPTION
## Summary

Notification banner and Details focus rings render at 3px while the rest of the system uses 2px (`--goa-border-width-l`). This updates the 7 tokens that hardcoded 3px to reference the global border-width token instead.

- 6 `notification-banner-*-focus-border` tokens: `0 0 0 3px {color}` becomes `0 0 0 {borderWidth.l} {color}`.
- `details-focus-border` width changes from `{borderWidth.xl}` (3px) to `{borderWidth.l}` (2px).

No structural changes, just value swaps. Surfaced in GovAlta/ui-components#3605.

## Test plan

- [x] `npm run build` regenerates `dist/tokens.css` and `dist/tokens.scss` with the new values.
- [ ] Bump the pinned design-tokens version in ui-components after release; verify focus rings render at 2px on the #3605 playground.