### PR TITLE
chore: Update GITHUB_TOKEN in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,6 @@ jobs:
               { name: "dev", prerelease: true }
             ]
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_GRANULAR }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_GRANULAR }}


### PR DESCRIPTION
This should fix the Github release issue where it was failing due to bad credentials. This is the same fix applied to the ui-components repo to use the automatically created token when the build starts.