### PR TITLE
feat(#3858): add icon button tertiary border tokens

### DIFF
--- a/data/component-design-tokens/icon-button-design-tokens.json
+++ b/data/component-design-tokens/icon-button-design-tokens.json
@@ -88,5 +88,17 @@
   "icon-button-destructive-disabled-color": {
     "value": "{color.greyscale.500}",
     "type": "color"
+  },
+  "icon-button-tertiary-border-width": {
+    "value": "{borderWidth.s}",
+    "type": "borderWidth"
+  },
+  "icon-button-tertiary-border-color": {
+    "value": "{color.greyscale.200}",
+    "type": "color"
+  },
+  "icon-button-tertiary-destructive-border-color": {
+    "value": "{color.emergency.light}",
+    "type": "color"
   }
 }

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Jun 2026 22:07:38 GMT
+ * Generated on Wed, 08 Jul 2026 17:42:22 GMT
  */
 
 :root {
@@ -755,6 +755,9 @@
   --goa-text-input-space-btw-icon-text: var(--goa-space-xs);
   --goa-text-input-padding-lr: var(--goa-space-m);
   --goa-text-input-lt-content-color-bg: var(--goa-color-greyscale-150);
+  --goa-icon-button-tertiary-destructive-border-color: var(--goa-color-emergency-light);
+  --goa-icon-button-tertiary-border-color: var(--goa-color-greyscale-200);
+  --goa-icon-button-tertiary-border-width: var(--goa-border-width-s);
   --goa-icon-button-destructive-disabled-color: var(--goa-color-greyscale-500);
   --goa-icon-button-destructive-hover-color-bg: var(--goa-color-emergency-light);
   --goa-icon-button-destructive-hover-color: var(--goa-color-emergency-dark);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 24 Jun 2026 22:07:38 GMT
+// Generated on Wed, 08 Jul 2026 17:42:22 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
 $goa-accordion-color-filled-bg-heading: #f2f0f0;
@@ -625,6 +625,9 @@ $goa-icon-button-destructive-color: #da291c;
 $goa-icon-button-destructive-hover-color: #a91a10;
 $goa-icon-button-destructive-hover-color-bg: #fdded9;
 $goa-icon-button-destructive-disabled-color: #808080;
+$goa-icon-button-tertiary-border-width: 1px;
+$goa-icon-button-tertiary-border-color: #cdcdcd;
+$goa-icon-button-tertiary-destructive-border-color: #fdded9;
 $goa-text-input-border: inset 0 0 0 1px #808080;
 $goa-text-input-border-disabled: inset 0 0 0 1px #b1b1b1;
 $goa-text-input-border-error: inset 0 0 0 1.5px #ec040b;


### PR DESCRIPTION
Companion to the Icon Button tertiary type (GovAlta/ui-components#3858, PR GovAlta/ui-components#4128).

Adds three Icon Button tertiary tokens, mirroring Button's tertiary border recipe:

| Token | Value |
| --- | --- |
| `icon-button-tertiary-border-width` | `{borderWidth.s}` |
| `icon-button-tertiary-border-color` | `{color.greyscale.200}` |
| `icon-button-tertiary-destructive-border-color` | `{color.emergency.light}` |

`dist/` output committed per repo convention.

Merge order doesn't matter: the component CSS in ui-components falls back to the global tokens (`--goa-border-width-s`, `--goa-color-greyscale-200`, `--goa-color-emergency-light`) until these publish, then picks up the component tokens automatically.
