### PR TITLE
fix(#3609): make modal actions padding symmetric and align with content edges

### DIFF
--- a/data/component-design-tokens/modal-design-tokens.json
+++ b/data/component-design-tokens/modal-design-tokens.json
@@ -116,9 +116,9 @@
     "description": "Content section padding"
   },
   "modal-actions-padding": {
-    "value": "{space.xs} {space.xl} {space.xl} {space.xl}",
+    "value": "{space.l}",
     "type": "spacing",
-    "description": "Actions section padding"
+    "description": "Actions section padding, symmetric and matching content edges (24px all sides)"
   },
   "modal-content-wrapper-padding": {
     "value": "0",
@@ -161,9 +161,9 @@
     "description": "Content section padding for desktop (24px top, 24px sides, 32px bottom)"
   },
   "modal-actions-padding-mobile": {
-    "value": "{space.xs} {space.m} {space.m} {space.m}",
+    "value": "{space.m}",
     "type": "spacing",
-    "description": "Actions section padding for mobile (8px top, 16px sides and bottom)"
+    "description": "Actions section padding for mobile, symmetric and matching content edges (16px all sides)"
   },
   "modal-callout-information-bg": {
     "value": "{color.info.light}",

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 08 Jul 2026 17:42:22 GMT
+ * Generated on Mon, 20 Jul 2026 23:08:41 GMT
  */
 
 :root {
@@ -692,7 +692,7 @@
   --goa-modal-callout-information-icon: var(--goa-color-info-default);
   --goa-modal-callout-information-border: var(--goa-color-info-border);
   --goa-modal-callout-information-bg: var(--goa-color-info-light);
-  --goa-modal-actions-padding-mobile: var(--goa-space-xs) var(--goa-space-m) var(--goa-space-m) var(--goa-space-m);
+  --goa-modal-actions-padding-mobile: var(--goa-space-m);
   --goa-modal-content-padding-desktop: var(--goa-space-l) var(--goa-space-l) var(--goa-space-xl) var(--goa-space-l);
   --goa-modal-content-padding-mobile: var(--goa-space-xl) var(--goa-space-m) var(--goa-space-xl) var(--goa-space-m);
   --goa-modal-callout-heading-padding-mobile: var(--goa-space-m);
@@ -700,7 +700,7 @@
   --goa-modal-callout-heading-padding: var(--goa-space-m) var(--goa-space-l);
   --goa-modal-scrollable-padding-mobile: var(--goa-space-m);
   --goa-modal-scrollable-padding-desktop: var(--goa-space-l);
-  --goa-modal-actions-padding: var(--goa-space-xs) var(--goa-space-xl) var(--goa-space-xl) var(--goa-space-xl);
+  --goa-modal-actions-padding: var(--goa-space-l);
   --goa-modal-content-padding: var(--goa-space-xl) 0 var(--goa-space-xl) 0;
   --goa-modal-heading-padding: 20px var(--goa-space-l);
   --goa-modal-border: var(--goa-border-width-s) solid var(--goa-color-greyscale-150);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 08 Jul 2026 17:42:22 GMT
+// Generated on Mon, 20 Jul 2026 23:08:41 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
 $goa-accordion-color-filled-bg-heading: #f2f0f0;
@@ -724,7 +724,7 @@ $goa-modal-max-width: 480px;
 $goa-modal-heading-border-bottom: none;
 $goa-modal-heading-padding: 20px 1.5rem;
 $goa-modal-content-padding: 2rem 0 2rem 0;
-$goa-modal-actions-padding: 0.5rem 2rem 2rem 2rem;
+$goa-modal-actions-padding: 1.5rem;
 $goa-modal-content-wrapper-padding: 0;
 $goa-modal-scrollable-padding-desktop: 1.5rem;
 $goa-modal-scrollable-padding-mobile: 1rem;
@@ -733,7 +733,7 @@ $goa-modal-heading-padding-mobile: 1rem;
 $goa-modal-callout-heading-padding-mobile: 1rem;
 $goa-modal-content-padding-mobile: 2rem 1rem 2rem 1rem;
 $goa-modal-content-padding-desktop: 1.5rem 1.5rem 2rem 1.5rem;
-$goa-modal-actions-padding-mobile: 0.5rem 1rem 1rem 1rem;
+$goa-modal-actions-padding-mobile: 1rem;
 $goa-modal-callout-information-bg: #ebf8ff;
 $goa-modal-callout-information-border: #cbeaf7;
 $goa-modal-callout-information-icon: #0077ad;


### PR DESCRIPTION
## Summary

Makes the V2 modal actions (footer) padding symmetric so the action buttons no longer read as cramped against the footer edges.

The actions section top padding was much smaller than the bottom padding on both breakpoints (8px vs 32px on desktop, 8px vs 16px on mobile), so the Cancel / Save buttons sat too close to the modal's bottom edge. On desktop the left/right padding also did not match the content section's edges.

## Change

| token | before | after |
| --- | --- | --- |
| `modal-actions-padding` | `{space.xs} {space.xl} {space.xl} {space.xl}` (8/32/32/32) | `{space.l}` (24px all sides) |
| `modal-actions-padding-mobile` | `{space.xs} {space.m} {space.m} {space.m}` (8/16/16/16) | `{space.m}` (16px all sides) |

Desktop now matches the content section's 24px left/right padding, so the buttons align with the content edges.

## Downstream

Once published, ui-components will bump to the new version and drop the interim component level override. Tracking PR: GovAlta/ui-components#4147.

Fixes #3609
