### PR TITLE
fix(#4198): correct dropdown placeholder and option text colours

### DIFF
--- a/data/component-design-tokens/dropdown-design-tokens.json
+++ b/data/component-design-tokens/dropdown-design-tokens.json
@@ -53,7 +53,7 @@
     "type": "color"
   },
   "dropdown-color-text-placeholder": {
-    "value": "{input.color.text.default}",
+    "value": "{input.color.text.placeholder}",
     "type": "color"
   },
   "dropdown-color-text-error": {
@@ -81,7 +81,7 @@
     "type": "color"
   },
   "dropdown-item-color-text": {
-    "value": "{color.text.secondary}",
+    "value": "{color.text.default}",
     "type": "color"
   },
   "dropdown-item-color-text-disabled": {

--- a/data/component-design-tokens/dropdown-multiselect-design-tokens.json
+++ b/data/component-design-tokens/dropdown-multiselect-design-tokens.json
@@ -45,7 +45,7 @@
     "type": "color"
   },
   "dropdown-multiselect-color-text-placeholder": {
-    "value": "{input.color.text.default}",
+    "value": "{input.color.text.placeholder}",
     "type": "color"
   },
   "dropdown-multiselect-color-text-error": {

--- a/dist/tokens.css
+++ b/dist/tokens.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 29 Jul 2026 00:02:36 GMT
+ * Generated on Wed, 05 Aug 2026 16:49:19 GMT
  */
 
 :root {
@@ -1292,6 +1292,7 @@
   --goa-dropdown-multiselect-item-color-bg-disabled: var(--goa-input-color-background-disabled);
   --goa-dropdown-multiselect-item-color-bg: var(--goa-input-color-background-default);
   --goa-dropdown-multiselect-color-text-error: var(--goa-input-color-text-error);
+  --goa-dropdown-multiselect-color-text-placeholder: var(--goa-input-color-text-placeholder);
   --goa-dropdown-multiselect-color-text-disabled: var(--goa-input-color-text-disabled);
   --goa-dropdown-multiselect-color-bg-disabled: var(--goa-input-color-background-disabled);
   --goa-dropdown-multiselect-color-bg: var(--goa-input-color-background-default);
@@ -1311,10 +1312,11 @@
   --goa-dropdown-item-color-text-selected-hover: var(--goa-color-text-light);
   --goa-dropdown-item-color-text-hover: var(--goa-color-text-default);
   --goa-dropdown-item-color-text-disabled: var(--goa-color-text-disabled);
-  --goa-dropdown-item-color-text: var(--goa-color-text-secondary);
+  --goa-dropdown-item-color-text: var(--goa-color-text-default);
   --goa-dropdown-item-color-bg-disabled: var(--goa-input-color-background-disabled);
   --goa-dropdown-item-color-bg: var(--goa-input-color-background-default);
   --goa-dropdown-color-text-error: var(--goa-input-color-text-error);
+  --goa-dropdown-color-text-placeholder: var(--goa-input-color-text-placeholder);
   --goa-dropdown-color-text-disabled: var(--goa-input-color-text-disabled);
   --goa-dropdown-color-bg-error: var(--goa-input-color-background-error);
   --goa-dropdown-color-bg-disabled: var(--goa-input-color-background-disabled);
@@ -1389,9 +1391,7 @@
   --goa-accordion-color-heading-hover: var(--goa-color-text-default);
   --goa-accordion-color-heading: var(--goa-color-text-default);
   --goa-text-input-color-text: var(--goa-input-color-text-default);
-  --goa-dropdown-multiselect-color-text-placeholder: var(--goa-input-color-text-default);
   --goa-dropdown-multiselect-color-text: var(--goa-input-color-text-default);
-  --goa-dropdown-color-text-placeholder: var(--goa-input-color-text-default);
   --goa-dropdown-color-text: var(--goa-input-color-text-default);
   --goa-date-input-day-color-text-hover: var(--goa-input-color-text-default);
   --goa-date-input-day-color-text: var(--goa-input-color-text-default);

--- a/dist/tokens.scss
+++ b/dist/tokens.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Wed, 29 Jul 2026 00:02:36 GMT
+// Generated on Wed, 05 Aug 2026 16:49:19 GMT
 
 $goa-accordion-color-bg-heading: #ffffff;
 $goa-accordion-color-filled-bg-heading: #f2f0f0;
@@ -371,14 +371,14 @@ $goa-dropdown-color-bg-error: #fdded9;
 $goa-dropdown-color-bg-error-hover: #f4c8c5;
 $goa-dropdown-color-text: #000000;
 $goa-dropdown-color-text-disabled: #808080;
-$goa-dropdown-color-text-placeholder: #000000;
+$goa-dropdown-color-text-placeholder: #9f9f9f;
 $goa-dropdown-color-text-error: #a91a10;
 $goa-dropdown-item-color-bg: #ffffff;
 $goa-dropdown-item-color-bg-disabled: #e9e9e9;
 $goa-dropdown-item-color-bg-hover: #f2f0f0;
 $goa-dropdown-item-color-bg-selected: #006dcc;
 $goa-dropdown-item-color-bg-selected-hover: #045092;
-$goa-dropdown-item-color-text: #6f6f6f;
+$goa-dropdown-item-color-text: #000000;
 $goa-dropdown-item-color-text-disabled: #4d4d4d;
 $goa-dropdown-item-color-text-hover: #000000;
 $goa-dropdown-item-color-text-selected: #ffffff;
@@ -412,7 +412,7 @@ $goa-dropdown-multiselect-color-bg: #ffffff;
 $goa-dropdown-multiselect-color-bg-disabled: #e9e9e9;
 $goa-dropdown-multiselect-color-text: #000000;
 $goa-dropdown-multiselect-color-text-disabled: #808080;
-$goa-dropdown-multiselect-color-text-placeholder: #000000;
+$goa-dropdown-multiselect-color-text-placeholder: #9f9f9f;
 $goa-dropdown-multiselect-color-text-error: #a91a10;
 $goa-dropdown-multiselect-item-color-bg: #ffffff;
 $goa-dropdown-multiselect-item-color-bg-disabled: #e9e9e9;


### PR DESCRIPTION
Fixes the inverted text weighting in both dropdowns. Today the `—Select—` placeholder is the darkest text in the component and the options are the lightest, so an empty field reads as filled.

<img width="1278" height="444" alt="image" src="https://github.com/user-attachments/assets/342dc6da-92c8-43ed-a214-6edc0d273a39" />
<img width="1278" height="558" alt="image" src="https://github.com/user-attachments/assets/6375832a-cd8f-4a0a-80a4-31e42e77dec5" />


Three values in `data/component-design-tokens/`:

| token | was | now |
|---|---|---|
| `dropdown-color-text-placeholder` | `{input.color.text.default}` | `{input.color.text.placeholder}` |
| `dropdown-multiselect-color-text-placeholder` | `{input.color.text.default}` | `{input.color.text.placeholder}` |
| `dropdown-item-color-text` | `{color.text.secondary}` | `{color.text.default}` |

Resolved, that is placeholders from #000000 to #9f9f9f and options from #6f6f6f to #000000. `dist/tokens.css` and `dist/tokens.scss` are regenerated with `node index.js`. `dist/dark-theme.css` is unchanged.

Both placeholder tokens now match `text-input-color-text-placeholder` and `text-area-color-text-placeholder`, which already point at the placeholder colour. `dropdown-item-color-text` now matches `dropdown-item-color-text-hover` by reference rather than by coincidence of value.

Checked against a local preview rendering real V2 components on both built token files side by side, in light and dark mode:

1. Dark mode inherits the fix with no dark-theme change, because both tokens resolve through greyscale primitives that dark theme already overrides. Placeholder goes #d4d4d4 to #6a6a6a, options #999999 to #d4d4d4.
2. Hover and selected states are unchanged and still carry their own background change.
3. Text input and text area are untouched at #9f9f9f.

Multiselect options are deliberately not part of this change. They are `goa-checkbox` elements, so their text comes from `checkbox-color-label` at #353535, which is already near black. Matching #000000 exactly would repaint every checkbox in the system for a #353535 to #000000 difference.

`dropdown-multiselect-item-color-text` is left alone and now looks inconsistent beside `dropdown-item-color-text`. It has zero references in the codebase, as does `dropdown-multiselect-item-color-bg-hover`, so changing it does nothing visible. Cleanup candidate, out of scope here.

On contrast, the placeholder sits at 2.65:1 in light and 2.80:1 in dark. That is the same value text input and text area already use. The placeholder is not the accessible name, a visible form label carries that, and the options half of this change raises option text from 5.02:1 to 21:1.

Merging this publishes, so the merge is the release. Nothing reaches consuming teams until the ui-components pin at `@abgov/design-tokens-v2` moves off 2.12.0.

That follow through is already staged in GovAlta/ui-components#4199, currently in draft. It carries the two Dropdown Multiselect placeholder fallbacks and playground pages at `bugs/4198` in both the React and Angular playgrounds. Once this merges and publishes, that PR takes the pin bump and comes out of draft.
